### PR TITLE
US93 Transfer Form

### DIFF
--- a/client/src/components/CosmologyForm.vue
+++ b/client/src/components/CosmologyForm.vue
@@ -45,7 +45,7 @@ export default {
   },
   data: () => ({
     inputs: {
-      h0: {
+      H0: {
         html: '<label>H<sub>0</sub></label>',
         min: 10,
         max: 500,

--- a/client/src/components/FormNumberField.vue
+++ b/client/src/components/FormNumberField.vue
@@ -52,7 +52,8 @@ export default {
         const parsedNum = Number.parseFloat(value);
 
         // Determine if the number is within bounds
-        if (parsedNum <= this.max && parsedNum >= this.min) {
+        if ((this.max === null || this.min === null)
+        || (parsedNum <= this.max && parsedNum >= this.min)) {
           this.setCurrentValue(Number.parseFloat(value));
           this.inputIsInvalid = false;
         } else {

--- a/client/src/components/FormNumberField.vue
+++ b/client/src/components/FormNumberField.vue
@@ -51,9 +51,15 @@ export default {
       if (!Number.isNaN(value)) {
         const parsedNum = Number.parseFloat(value);
 
+        // Determine if there are min and max bounds
+        if (this.max === undefined || this.min === undefined) {
+          this.setCurrentValue(Number.parseFloat(value));
+          this.inputIsInvalid = false;
+          return;
+        }
+
         // Determine if the number is within bounds
-        if ((this.max === null || this.min === null)
-        || (parsedNum <= this.max && parsedNum >= this.min)) {
+        if (parsedNum <= this.max && parsedNum >= this.min) {
           this.setCurrentValue(Number.parseFloat(value));
           this.inputIsInvalid = false;
         } else {

--- a/client/src/components/TransferForm.vue
+++ b/client/src/components/TransferForm.vue
@@ -6,7 +6,6 @@
         v-model="transferChoice"
         id="transferChoices"
         name="transferChoice"
-        v-on:change="doSomething"
       >
         <md-option
           v-for="(value, key) in transferChoices"
@@ -28,6 +27,10 @@
         :setCurrentValue="createSetCurrentValueFunc(transferModel, inputName)"
       />
     </div>
+
+    <md-checkbox v-model="takahashiChoice">
+      Use Takahashi (2012) nonlinear P(k)?
+    </md-checkbox>
 
   </div>
 </template>
@@ -55,6 +58,7 @@ export default {
   data: () => ({
     transferChoices,
     transferChoice: '',
+    takahashiChoice: false,
   }),
   components: {
     FormNumberField,
@@ -76,13 +80,13 @@ export default {
         this.setTransferParams(this.transferParams);
       };
     },
-    doSomething() {
-      console.log('Did something');
-    },
   },
   watch: {
     transferChoice() {
       this.setTransferModel(this.transferChoice);
+    },
+    takahashiChoice() {
+      this.setTakahashi(this.takahashiChoice);
     },
   },
 };

--- a/client/src/components/TransferForm.vue
+++ b/client/src/components/TransferForm.vue
@@ -1,0 +1,93 @@
+<template>
+  <div>
+    <md-field>
+      <label for="transferChoices">Transfer Model</label>
+      <md-select
+        v-model="transferChoice"
+        id="transferChoices"
+        name="transferChoice"
+        v-on:change="doSomething"
+      >
+        <md-option
+          v-for="(value, key) in transferChoices"
+          :key="key"
+          :value="key"
+        >
+          {{value}}
+        </md-option>
+      </md-select>
+    </md-field>
+
+    <div v-if="transferParams[transferModel] !== undefined">
+      <FormNumberField
+        v-for="(input, inputName) in transferParams[transferModel]"
+        :labelHtml="'<label>' + inputName + '</label>'"
+        :key="inputName"
+        :step="1"
+        :currentValue="transferParams[transferModel][inputName]"
+        :setCurrentValue="createSetCurrentValueFunc(transferModel, inputName)"
+      />
+    </div>
+
+  </div>
+</template>
+
+<script>
+import FormNumberField from './FormNumberField.vue';
+
+const transferChoices = {
+  CAMB: 'CAMB',
+  EH_BAO: 'Eisenstein-Hu (1998) (with BAO)',
+  EH_NoBAO: 'Eisenstein-Hu (1998) (no BAO)',
+  BBKS: 'BBKS (1986)',
+  BondEfs: 'Bond-Efstathiou',
+};
+export default {
+  name: 'TransferForm',
+  props: {
+    transferParams: Object,
+    setTransferParams: Function,
+    takahashi: Boolean,
+    setTakahashi: Function,
+    transferModel: String,
+    setTransferModel: Function,
+  },
+  data: () => ({
+    transferChoices,
+    transferChoice: '',
+  }),
+  components: {
+    FormNumberField,
+  },
+  mounted() {
+    this.transferChoice = this.transferModel;
+  },
+  methods: {
+    /**
+     * Creates a current value setter for the given transfer type and variable
+     * name. This just applies to two transfer types at the moment.
+     */
+    createSetCurrentValueFunc(transferType, varName) {
+      return (newValue) => {
+        // Set the new value temporarily
+        this.transferParams[transferType][varName] = newValue;
+
+        // Set the value for good.
+        this.setTransferParams(this.transferParams);
+      };
+    },
+    doSomething() {
+      console.log('Did something');
+    },
+  },
+  watch: {
+    transferChoice() {
+      this.setTransferModel(this.transferChoice);
+    },
+  },
+};
+</script>
+
+<style>
+
+</style>

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -12,6 +12,7 @@ import {
   MdDrawer,
   MdList,
   MdApp,
+  MdCheckbox,
 } from 'vue-material/dist/components';
 import VueObserveVisibility from 'vue-observe-visibility';
 import 'vue-material/dist/vue-material.min.css';
@@ -32,6 +33,7 @@ Vue.use(MdMenu);
 Vue.use(MdList);
 Vue.use(MdDrawer);
 Vue.use(MdApp);
+Vue.use(MdCheckbox);
 
 const routes = [
   {

--- a/client/src/views/Create.vue
+++ b/client/src/views/Create.vue
@@ -31,12 +31,14 @@ import FormWrapper from '@/components/FormWrapper.vue';
 import ExampleForm from '@/components/ExampleForm.vue';
 import ExampleForm1 from '@/components/ExampleForm1.vue';
 import ExampleForm2 from '@/components/ExampleForm2.vue';
+import CosmologyForm from '@/components/CosmologyForm.vue';
 
 export default {
   name: 'Create',
   components: {
     FormWrapper,
     ExampleForm,
+    CosmologyForm,
   },
   data() {
     return {
@@ -46,6 +48,7 @@ export default {
         { component: ExampleForm, highlight: false, isVisible: false },
         { component: ExampleForm1, highlight: false, isVisible: false },
         { component: ExampleForm2, highlight: false, isVisible: false },
+        { component: CosmologyForm, highlight: false, isVisible: false },
       ],
     };
   },

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -2,8 +2,8 @@
   <div class="home">
     <CosmologyForm
       :hmfDefaults="hmfDefaults"
-      :setCosmo="createSetFormFunction('cosmo')"
-      :cosmoValues="modelData.cosmo"
+      :setCosmo="createParamsSetFunction('cosmo_params')"
+      :cosmoValues="params.cosmo_params"
     />
   </div>
 </template>
@@ -14,16 +14,40 @@ import CosmologyForm from '../components/CosmologyForm.vue';
 
 const debug = Debug('Home.vue');
 // Enable or disble debugging 🙂
-debug.enabled = false;
+debug.enabled = true;
 
 export default {
   name: 'Home',
+  // TODO: Make the data at the app level and learn how to pass this to routes
   data: () => ({
-    modelData: {
-      cosmo: {
-        h0: 0,
+    params: {
+      cosmo_model: 'Planck15',
+      cosmo_params: {
+        H0: 0,
         Ob0: 0,
         Om0: 0,
+      },
+      transfer: {
+        FromArray: {
+          k: null,
+          T: null,
+        },
+        EH_BAO: {},
+        EH_NoBAO: {},
+        BBKS: {
+          a: 2.34,
+          b: 3.89,
+          c: 16.1,
+          d: 5.47,
+          e: 6.71,
+        },
+        BondEfs: {
+          a: 37.1,
+          b: 21.1,
+          c: 10.8,
+          nu: 1.12,
+        },
+        EH: {},
       },
     },
     hmfDefaults: null,
@@ -35,18 +59,18 @@ export default {
   },
   methods: {
     /**
-     * Creates a form data editor for the `model` part of the data for the
+     * Creates a form data editor for the `params` part of the data for the
      * Home component. So this will create a function that can set any object
-     * below the `model` part of the model data structure.
+     * below the `params` part of the params data structure.
      *
-     * @param {String} formName the name of the form to create the set function
-     * for
+     * @param {String} objectName the name of the object to create the set
+     * function for
      * @returns {(value: Object) => null} the function that will set the form
      * value to what is provided
      */
-    createSetFormFunction(formName) {
+    createParamsSetFunction(objectName) {
       return (newObj) => {
-        this.modelData[formName] = newObj;
+        this.params[objectName] = newObj;
       };
     },
   },
@@ -54,18 +78,18 @@ export default {
     fetch(`${this.baseServerURL}/constants`).then((data) => data.json()).then((json) => {
       this.hmfDefaults = json.constantsFromHMF;
       this.defaultModel = json.defaultModel;
-      debug('modelData.cosmo is currently: ', this.modelData.cosmo);
       debug('json.constantsFromHMF.cosmo is currently: ', json.constantsFromHMF.cosmo);
 
       /* Set the default values for cosmo. This is done in this way so that
       * the observers are held. If the entire object is changed, it seems
       * that the observers are removed. This can be done in a similar way
       * for other deafult values. */
-      Object.keys(this.modelData.cosmo).forEach((key) => {
-        this.modelData.cosmo[key] = json.constantsFromHMF.cosmo.Planck15[key];
+      const cosmoModel = this.params.cosmo_model;
+      Object.keys(this.params.cosmo_params).forEach((key) => {
+        this.params.cosmo_params[key] = json.constantsFromHMF.cosmo[cosmoModel][key];
       });
 
-      debug('modelData.cosmo is now: ', this.modelData.cosmo);
+      debug('params is now: ', this.params);
     });
   },
 };

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -5,12 +5,22 @@
       :setCosmo="createParamsSetFunction('cosmo_params')"
       :cosmoValues="params.cosmo_params"
     />
+    <TransferForm
+      :setTakahashi="createParamsSetFunction('takahashi')"
+      :setTransferModel="createParamsSetFunction('transfer_model')"
+      :setTransferParams="createParamsSetFunction('transfer_params')"
+      :transferParams="params.transfer_params"
+      :takahashi="params.takahashi"
+      :transferModel="params.transfer_model"
+    />
   </div>
 </template>
 
 <script>
 import Debug from 'debug';
 import CosmologyForm from '../components/CosmologyForm.vue';
+import TransferForm from '../components/TransferForm.vue';
+import constants from '../constants/backend_constants';
 
 const debug = Debug('Home.vue');
 // Enable or disble debugging 🙂
@@ -27,28 +37,12 @@ export default {
         Ob0: 0,
         Om0: 0,
       },
-      transfer: {
-        FromArray: {
-          k: null,
-          T: null,
-        },
-        EH_BAO: {},
-        EH_NoBAO: {},
-        BBKS: {
-          a: 2.34,
-          b: 3.89,
-          c: 16.1,
-          d: 5.47,
-          e: 6.71,
-        },
-        BondEfs: {
-          a: 37.1,
-          b: 21.1,
-          c: 10.8,
-          nu: 1.12,
-        },
-        EH: {},
+      transfer_params: {
+        BBKS: constants.TransferComponent_params.BBKS,
+        BondEfs: constants.TransferComponent_params.BondEfs,
       },
+      takahashi: true,
+      transfer_model: 'CAMB',
     },
     hmfDefaults: null,
     defaultModel: null,
@@ -56,21 +50,22 @@ export default {
   }),
   components: {
     CosmologyForm,
+    TransferForm,
   },
   methods: {
     /**
      * Creates a form data editor for the `params` part of the data for the
-     * Home component. So this will create a function that can set any object
-     * below the `params` part of the params data structure.
+     * Home component. So this will create a function that can set any value
+     * for a key below the `params` part of the params data structure.
      *
-     * @param {String} objectName the name of the object to create the set
+     * @param {String} keyName the name of the key to create the set
      * function for
-     * @returns {(value: Object) => null} the function that will set the form
+     * @returns {(value: any) => null} the function that will set the form
      * value to what is provided
      */
-    createParamsSetFunction(objectName) {
-      return (newObj) => {
-        this.params[objectName] = newObj;
+    createParamsSetFunction(keyName) {
+      return (newVal) => {
+        this.params[keyName] = newVal;
       };
     },
   },

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,21 @@
+### Overview
+The overview represents a high-level description of the changes which were introduced, including why they were introduced, and how they impact the user/developer experience. If appropriate, add screenshots/screen recordings reflecting the impact the change has to the user experience.
+When a code reviewer has a more complete understanding of how and why a particular set of code changes were introduced, they are able to review and respond to changes faster and more effectively.
+
+### Includes:
+- Enumerate the file-level changes which were introduced
+- path/to/file.java
+- path/to/file2.java
+
+### Developer Checklist:
+- [ ] The code follows the Quality Policy file on Google Drive
+- [ ] My code has been developer-tested and includes unit tests
+- [ ] I have considered proper use of exceptions
+- [ ] I have eliminated IDE warnings
+
+### Notes:
+- Talk about alternative solutions you considered, any potential breaking changes, integration testing strategies, motivation or reasoning for the introduced changes, and/or any other pertinent information which would better inform a code reviewer of your changes.
+- This section can be omitted if the scope of the change does not necessitate it.
+
+### Refs:
+- [Ticket](https://ticketlink.com)

--- a/server/halomod_app/__init__.py
+++ b/server/halomod_app/__init__.py
@@ -36,7 +36,7 @@ cosmo_choices = [
 for choice in cosmo_choices:
     cosmo_model = hmf.cosmo.Cosmology(cosmo_model=getattr(hmf.cosmo, choice))
     hmf_defaults.get('cosmo').setdefault(choice, {
-        "h0": cosmo_model.cosmo.H0.value,
+        "H0": cosmo_model.cosmo.H0.value,
         "Ob0": cosmo_model.cosmo.Ob0,
         "Om0": cosmo_model.cosmo.Om0
     })


### PR DESCRIPTION
## Overview

This PR implements the Transfer form, User Story 93. This also adds `md-checkbox` to the application and a very small update to `FormNumberField.vue` to check for the existence of min/max values.

This PR also modifies how the main model data looks so it more closely resembles `server/thm_payload_create.json`. This should hopefully allow us to simply take the current state of `params` and pass it to the server when calculations need to be made. 

### Pull Request Template

A pull request template was added so we don't have to copy and paste from Slack. This will only take effect once it is pulled into main though. 

## Includes:
- client/src/components/CosmologyForm.vue 
- client/src/components/FormNumberField.vue 
- client/src/components/TransferForm.vue 
- client/src/router/index.js 
- client/src/views/Create.vue 
- client/src/views/Home.vue 
- docs/pull_request_template.md 
- server/halomod_app/__init__.py 

## Developer Checklist:
- [x] The code follows the Quality Policy file on Google Drive
- [ ] My code has been developer-tested and includes unit tests
- [x] I have considered proper use of exceptions
- [x] I have eliminated IDE warnings

### Refs:
- [US 93](https://the-halo-mod.atlassian.net/jira/software/projects/HM/boards/1?selectedIssue=HM-93)