### PR TITLE
US101 HMF Form Implementation

### DIFF
--- a/client/src/components/HMFForm.vue
+++ b/client/src/components/HMFForm.vue
@@ -1,0 +1,113 @@
+<template>
+  <form novalidate>
+    <double-field
+      param="Mass Range Min (log10)"
+      v-model="model.Mmin"
+      :value="model.Mmin"
+      :placeholder="core_defaults.Mmin"
+      range=true min=0 max=20 />
+    <double-field
+      param="Mass Range Max (log10)"
+      v-model="model.Mmax"
+      :value="model.Mmax"
+      :placeholder="core_defaults.Mmax"
+      range=true min=0 max=20 />
+    <double-field
+      param="Mass resolution (log10)"
+      v-model="model.dlog10m"
+      :value="model.dlog10m"
+      :placeholder="core_defaults.dlog10m"
+      range=true min=0.005 max=1 />
+    <md-field>
+      <label>HMF</label>
+      <md-select v-model="model.hmf_model">
+        <md-option
+          v-for="(value, choice) in choices"
+          :key="choice"
+          :value="value">
+          {{choice}}
+        </md-option>
+      </md-select>
+    </md-field>
+    <double-field
+      v-for="(value, param) in model.hmf_params"
+      :value="value"
+      :key="param"
+      :param="param"
+      range=false
+      :placeholder="String(param_defaults[param])"
+      v-model="model.hmf_params[param]"/>
+  </form>
+</template>
+
+<script>
+import DoubleField from './DoubleField.vue';
+import BACKEND_CONSTANTS from '../constants/backend_constants';
+
+const hmfChoices = {
+  'Press-Schechter (1974)': 'PS',
+  'Sheth-Mo-Tormen (2001)': 'SMT',
+  'Jenkins (2001)': 'Jenkins',
+  'Reed (2003)': 'Reed03',
+  'Warren (2006)': 'Warren',
+  'Reed (2007)': 'Reed07',
+  'Peaock (2007)': 'Peacock',
+  'Tinker (2008)': 'Tinker08',
+  'Crocce (2010)': 'Crocce',
+  'Courtin (2010)': 'Courtin',
+  'Tinker (2010)': 'Tinker10',
+  'Bhattacharya (2011)': 'Bhattacharya',
+  'Angulo (2012)': 'Angulo',
+  'Angulo (Subhaloes) (2012)': 'AnguloBound',
+  'Watson (FoF Universal) (2012)': 'Watson_FoF',
+  'Watson (Redshift Dependent) (2012)': 'Watson',
+  'Behroozi (Tinker Extension to High-z) (2013)': 'Behroozi',
+  'Pillepich (2010)': 'Pillepich',
+  'Manera (2010)': 'Manera',
+  'Ishiyama (2015)': 'Ishiyama',
+};
+
+export default {
+  title: 'HMF',
+  id: 'hmf',
+  name: 'HMFForm',
+  model: {
+    event: 'onChange',
+    prop: 'parent_model',
+  },
+  props: ['parent_model'],
+  data() {
+    return {
+      model: {
+        Mmin: BACKEND_CONSTANTS.Mmin,
+        Mmax: BACKEND_CONSTANTS.Mmax,
+        dlog10m: BACKEND_CONSTANTS.dlog10m,
+        hmf_model: 'Tinker08',
+        hmf_params: BACKEND_CONSTANTS.FittingFunction_params.Tinker08,
+      },
+      core_defaults: {
+        Mmin: BACKEND_CONSTANTS.Mmin,
+        Mmax: BACKEND_CONSTANTS.Mmax,
+        dlog10m: BACKEND_CONSTANTS.dlog10m,
+      },
+      param_defaults: { ...BACKEND_CONSTANTS.FittingFunction_params.Tinker08 },
+      choices: hmfChoices,
+    };
+  },
+  updated() {
+    this.$emit('onChange', this.model);
+  },
+  watch: {
+    'model.hmf_model': function updateOptions(val) {
+      this.model.hmf_params = null;
+      this.$nextTick(function saveNewOptions() {
+        this.model.hmf_params = BACKEND_CONSTANTS.FittingFunction_params[val];
+        this.param_defaults = BACKEND_CONSTANTS.FittingFunction_params[val];
+      });
+    },
+  },
+  components: {
+    DoubleField,
+  },
+};
+</script>

--- a/client/src/views/Create.vue
+++ b/client/src/views/Create.vue
@@ -46,14 +46,6 @@ export default {
     params: null,
     forms: null,
   }),
-  watch: {
-    'params.hmf': {
-      deep: true,
-      handler() {
-        console.log(this.params.hmf);
-      },
-    },
-  },
   methods: {
     createForms() {
       // Add forms to this list, and remove the example form.

--- a/client/src/views/Create.vue
+++ b/client/src/views/Create.vue
@@ -33,6 +33,7 @@
 import FormWrapper from '@/components/FormWrapper.vue';
 import HaloExclusion from '@/components/HaloExclusion.vue';
 import BiasForm from '@/components/BiasForm.vue';
+import HMFForm from '@/components/HMFForm.vue';
 import INITIAL_STATE from '@/constants/initial_state.json';
 
 export default {
@@ -45,6 +46,14 @@ export default {
     params: null,
     forms: null,
   }),
+  watch: {
+    'params.hmf': {
+      deep: true,
+      handler() {
+        console.log(this.params.hmf);
+      },
+    },
+  },
   methods: {
     createForms() {
       // Add forms to this list, and remove the example form.
@@ -57,6 +66,10 @@ export default {
         {
           component: BiasForm,
           model: 'bias',
+        },
+        {
+          component: HMFForm,
+          model: 'hmf',
         },
       ];
       forms.forEach((item) => {


### PR DESCRIPTION
Overview
This branch implements the HMFForm and integrates it with the create view. The pattern used for it is identical to the one used for BiasForm & that pull request should be confirmed first.

Includes:
client/src/components/HMFForm.vue
client/src/views/Home.vue

Developer Checklist:

- [X] The code follows the Quality Policy file on Google Drive

N/A My code has been developer-tested and includes unit tests

- [X] I have considered proper use of exceptions

- [X] I have eliminated IDE warnings