### PR TITLE
Tracer concentration fix

### DIFF
--- a/client/src/views/Create.vue
+++ b/client/src/views/Create.vue
@@ -88,6 +88,15 @@ export default {
         },
         {
           component: Concentration,
+          model: 'tracer_concentration',
+          props: {
+            title: 'Tracer Concentration',
+            id: 'tracer-concentration',
+            defaultModel: 'Bullock01',
+          },
+        },
+        {
+          component: Concentration,
           model: 'halo_concentration',
           props: {
             title: 'Halo Concentration',


### PR DESCRIPTION
tracer concentration disappeared from dev for some reason, it existed during the demo. 

There's only one change involved