### PR TITLE
Minor changes to support store usability by front end

### DIFF
--- a/client/src/utils/Store.js
+++ b/client/src/utils/Store.js
@@ -29,7 +29,7 @@ export default class API {
     });
     await Promise.all(models);
 
-    this.state.models = Object.fromEntries(map);
+    this.state.models = Object.fromEntries(models);
   }
 
   /**

--- a/client/src/utils/Store.js
+++ b/client/src/utils/Store.js
@@ -26,9 +26,10 @@ export default class API {
     k.forEach((key) => {
       const obj = get(key);
       models.set(key, obj);
-      this.state.models[key] = obj;
     });
     await Promise.all(models);
+
+    this.state.models = Object.fromEntries(map);
   }
 
   /**


### PR DESCRIPTION
Hi this is a followup to Michael's pull request that ever so slightly restructures how data is stored (using an object instead of a map)

These changes let any vue component save a reference to the stores state locally like
`data: { READ_ONLY: this.$store.state }`
and then use values within for v-binds & computed components.

As an example, if I want to v-bind the src of an image tag to the thing stored in the store, I just have 
`<img :src="READ_ONLY.plot"/>`

or if I want to always maintain current keys in v-for I can:
```
<div v-for="name in READ_ONLY.models.keys()">
  Do stuff.
<div>
```

Be mindful that you should never modify this state object directly -- consider it read only because the store does a lot of work to keep browser, server and cache in sync. Use functions from the store class any time you need to make a mutation.