### PR TITLE
Scroll Tracking Fix

### DIFF
--- a/client/src/components/FormWrapper.vue
+++ b/client/src/components/FormWrapper.vue
@@ -1,7 +1,17 @@
 <template>
   <div class="wrapper">
-    <div v-observe-visibility="visibilityChanged">
-      <h2 class="md-title">{{name}}</h2>
+    <div>
+      <h2 class="md-title"
+        v-observe-visibility="{
+          callback: visibilityChanged,
+          intersection: {
+            rootMargin: '0px 0px -70% 0px',
+            threshold: '.1',
+          },
+
+      }">
+      {{name}}
+    </h2>
       <slot/>
     </div>
   </div>
@@ -13,7 +23,7 @@ export default {
   props: ['name'],
   methods: {
     visibilityChanged(isVisible) {
-      this.$emit('toggle-highlight', isVisible);
+      if (isVisible) this.$emit('currently-visible', this.name);
     },
   },
 };

--- a/client/src/views/Create.vue
+++ b/client/src/views/Create.vue
@@ -18,8 +18,8 @@
       <div v-for="(form, index) in forms" :key="index">
         <FormWrapper
           :name="form.name"
-          v-bind:id="`${form.props ? form.props.id : form.component.id}`"
-          @currently-visible="(name) => setCurrentlyVisible(name)">
+          :id="form.id"
+          @currently-visible="() => setCurrentlyVisible(form.name, form.id)">
           <component v-if="form.isMeta"
             :is="form.component"
             :parent_model="model_metadata"
@@ -167,6 +167,7 @@ export default {
       forms.forEach((form) => {
         const lForm = form;
         lForm.name = lForm.props ? lForm.props.title : lForm.component.title;
+        lForm.id = lForm.props ? lForm.props.id : lForm.component.id;
       });
       this.forms = forms;
       this.$forceUpdate();
@@ -174,8 +175,9 @@ export default {
     updateModelMetaData(updatedMetaData) {
       this.$emit('update-metadata', updatedMetaData);
     },
-    setCurrentlyVisible(name) {
+    setCurrentlyVisible(name, id, prefix = '/create') {
       this.currentlyVisible = name;
+      window.history.replaceState({}, '', `${prefix}#${id}`);
     },
   },
   created() {

--- a/client/src/views/Create.vue
+++ b/client/src/views/Create.vue
@@ -7,7 +7,7 @@
     >
       <md-list v-for="(form, index) in forms" :key="index">
         <md-list-item
-          :class="{'router-link-active': form.highlight}"
+          :class="{'router-link-active': currentlyVisible == form.name}"
           v-bind:to="`#${form.props ? form.props.id : form.component.id}`">
           {{form.props ? form.props.title : form.component.title}}
         </md-list-item>
@@ -17,9 +17,9 @@
 
       <div v-for="(form, index) in forms" :key="index">
         <FormWrapper
-          :name="form.props ? form.props.title : form.component.title"
+          :name="form.name"
           v-bind:id="`${form.props ? form.props.id : form.component.id}`"
-          @toggle-highlight="(bool) => toggleHighlight(bool, form, index)">
+          @currently-visible="(name) => setCurrentlyVisible(name)">
           <component v-if="form.isMeta"
             :is="form.component"
             :parent_model="model_metadata"
@@ -78,6 +78,7 @@ export default {
   },
   data: () => ({
     forms: null,
+    currentlyVisible: null,
   }),
   methods: {
     createForms() {
@@ -163,48 +164,18 @@ export default {
           model: 'transfer',
         },
       ];
-      forms.forEach((item) => {
-        const i = item;
-        i.highlight = false;
-        i.isVisible = false;
+      forms.forEach((form) => {
+        const lForm = form;
+        lForm.name = lForm.props ? lForm.props.title : lForm.component.title;
       });
       this.forms = forms;
       this.$forceUpdate();
     },
-    toggleHighlight(bool, form, index) {
-      const f = form;
-      if (!bool) {
-        f.highlight = false;
-        if (index + 1 < this.forms.length) {
-          if (index === 0) {
-            this.handleTopForm(this.forms[index + 1], index + 1);
-          } else if (index - 1 >= 0 && !this.forms[index - 1].isVisible) {
-            this.handleTopForm(this.forms[index + 1], index + 1);
-          }
-        }
-      } else if (bool) {
-        if (index - 1 >= 0) {
-          if (!this.forms[index - 1].isVisible) {
-            this.handleTopForm(f, index);
-          }
-        } else {
-          this.handleTopForm(f, index);
-        }
-        if (index + 1 < this.forms.length) {
-          this.forms[index + 1].highlight = false;
-        }
-      }
-      f.isVisible = bool;
-      this.forms[index] = f;
-      this.$forceUpdate();
-    },
-    handleTopForm(form, index, prefix = '/create') {
-      const f = form;
-      f.highlight = true;
-      window.history.replaceState({}, '', `${prefix}#${form.props ? form.props.id : form.component.id}`);
-    },
     updateModelMetaData(updatedMetaData) {
       this.$emit('update-metadata', updatedMetaData);
+    },
+    setCurrentlyVisible(name) {
+      this.currentlyVisible = name;
     },
   },
   created() {


### PR DESCRIPTION
This is a refactor / overhaul of scroll tracking in our forms. Everything should be working now.

Expected Behavior: when the title of any sub-form crosses an intersection line towards the top of the modal viewport, the corresponding list item is highlighted and whatever was highlighted before isn't anymore.

This doesn't resolve issues with refreshing / direct routing already present in dev (would need to adopt routes for that).

Includes:
client/src/views/Create.vue
client/src/components/FormWrapper.vue

Developer Checklist:

- [X] The code follows the Quality Policy file on Google Drive
- [ ] My code has been developer-tested and includes unit tests
- [X] I have considered proper use of exceptions
- [X] I have eliminated IDE warnings